### PR TITLE
Ignore the checkpoints folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/


### PR DESCRIPTION
This folder contains files which are auto-generated by Jupyter, which are useful for local save
checkpoints, but we probably don't need to commit these files.